### PR TITLE
Timer support error corrections and enhancements

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -215,7 +215,7 @@
                    <string> ms</string>
                   </property>
                   <property name="minimum">
-                   <number>5000</number>
+                   <number>1000</number>
                   </property>
                   <property name="maximum">
                    <number>60000</number>
@@ -402,7 +402,7 @@
                    <string> ms</string>
                   </property>
                   <property name="minimum">
-                   <number>5000</number>
+                   <number>1000</number>
                   </property>
                   <property name="maximum">
                    <number>60000</number>
@@ -708,7 +708,7 @@
                    <string> ms</string>
                   </property>
                   <property name="minimum">
-                   <number>5000</number>
+                   <number>1000</number>
                   </property>
                   <property name="maximum">
                    <number>60000</number>

--- a/socket_test.py
+++ b/socket_test.py
@@ -127,6 +127,7 @@ class MyApp(QtWidgets.QMainWindow):
             self.on_tcp_server_message_send
         )
         # TCP server send timer
+        self._tcp_server_send_timer = None
         self.ui.spinBoxTcpServerSendTimerInterval.valueChanged.connect(
             self.on_tcp_server_send_timer_interval_changed
         )
@@ -144,6 +145,7 @@ class MyApp(QtWidgets.QMainWindow):
             self.on_tcp_client_message_send
         )
         # TCP client send timer
+        self._tcp_client_send_timer = None
         self.ui.spinBoxTcpClientSendTimerInterval.valueChanged.connect(
             self.on_tcp_client_send_timer_interval_changed
         )
@@ -173,6 +175,7 @@ class MyApp(QtWidgets.QMainWindow):
             1234)
 
         # UDP send timer
+        self._udp_send_timer = None
         self.ui.spinBoxUdpSendTimerInterval.valueChanged.connect(
             self.on_udp_send_timer_interval_changed
         )

--- a/tcpserver.py
+++ b/tcpserver.py
@@ -97,6 +97,10 @@ class TCPServer(QObject):
                                     data = self.connection.recv(4096)
                                 except socket.timeout as t_out:
                                     pass
+                                except ConnectionError:
+                                    self.connection.close()
+                                    self.status.emit(self.LISTEN, '')
+                                    break
                                 else:
                                     if data:
                                         self.message.emit(


### PR DESCRIPTION
Catched ConnectionError exception when self.connection.recv() is called
Initialized send timers to None 
Changed minimum time to 1000 ms